### PR TITLE
Update method so we can include event logo when publishing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 
 setup(
@@ -10,6 +13,9 @@ setup(
     author='Facebook',
     url='http://github.com/eventbrite/facebook-python-sdk',
     package_dir={'': 'src'},
+    install_requires=[
+        'requests>=2.4',
+    ],
     py_modules=[
         'facebook',
     ],


### PR DESCRIPTION
Update the GraphAPI.put_event method so we can publish the event photo/logo to
the Facebook page when publishing the event.