### PR TITLE
Publish to page

### DIFF
--- a/facebook/facebook.py
+++ b/facebook/facebook.py
@@ -92,7 +92,7 @@ class GraphAPI(object):
         self.access_token = access_token
         self.version = version
         self.host = "graph.facebook.com/"
-        self.url = "https://{}".format(
+        self.url = "https://{}/".format(
             self.host
         ) if not self.version else "https://{0}{1}/".format(
             self.host, self.version
@@ -169,11 +169,11 @@ class GraphAPI(object):
         """
 
         if id:
-            path = '/%s' % id
+            path = '%s' % id
         elif page_id:
-            path = '/%s/events' % page_id
+            path = '%s/events' % page_id
         else:
-            path = '/me/events'
+            path = 'me/events'
 
         response = self.request(path, post_args=data)
 


### PR DESCRIPTION
It appears Pages have a separate access token:
https://developers.facebook.com/docs/pages/access-tokens

Rewrote the put_event method to account for this for publishes to Pages.  Tested it locally and the event posted successfully to my test Page with the event image.