### PR TITLE
switch urlib to requests library

### DIFF
--- a/facebook/facebook.py
+++ b/facebook/facebook.py
@@ -143,7 +143,7 @@ class GraphAPI(object):
         return self.request(
             '{0}/{1}'.format(parent_object, connection_name),
             post_args=data,
-            method='POST'
+            method='POST',
         )
 
     def put_wall_post(self, message, attachment={}, profile_id="me"):
@@ -258,7 +258,7 @@ class GraphAPI(object):
 
     def delete_object(self, id):
         """Deletes the object with the given ID from the graph."""
-        return self.request(id, method="DELETE")
+        return self.request(id, method='DELETE')
 
     def get_permissions(self, id):
         """Takes a Facebook user ID and returns a dict of perms.
@@ -304,9 +304,9 @@ class GraphAPI(object):
         try:
             response = self.session.request(
                 method=method or 'GET',
-                url='{0}{1}'.format(self.url,  path),
-                data=post_args,
+                url='{0}{1}'.format(self.url, path),
                 params=args,
+                data=post_args,
                 timeout=self.timeout,
             )
         except requests.HTTPError as e:

--- a/facebook/facebook.py
+++ b/facebook/facebook.py
@@ -303,18 +303,18 @@ class GraphAPI(object):
 
         try:
             response = self.session.request(
-                method or "GET",
-                self.url + path + '?' + urllib.urlencode(args),
+                method=method or 'GET',
+                url='{0}{1}'.format(self.url,  path),
                 data=post_args,
+                params=args,
                 timeout=self.timeout,
             )
         except requests.HTTPError as e:
-            response = _parse_json(e.read())
-            if response.get("error"):
-                raise GraphAPIError(
-                    type=response["error"]["type"],
-                    message=response["error"]["message"]
-                )
+            error_response = _parse_json(e.read()) or {}
+            raise GraphAPIError(
+                type=error_response.get('error', {}).get('type'),
+                message=error_response.get('error', {}).get('message')
+            )
 
         return response.json()
 


### PR DESCRIPTION
Hi, we are having a terrible slowness in the requests to Facebook since 02/21/2017, we realized that urllib is taking ~70 sec to respond to a simple GET request in contrast to requests library where it's immediately.